### PR TITLE
Fix var macro syntax

### DIFF
--- a/src/Control/Toastr/templates/toastrControl.latte
+++ b/src/Control/Toastr/templates/toastrControl.latte
@@ -1,7 +1,7 @@
 {snippet messages}
 	<script n:nonce type="text/javascript">
 		{foreach $notifications as $notification}
-			{var type = $notification->getType()}
+			{var $type = $notification->getType()}
 
 			{if $type === $class::TYPE_ERROR || $type === 'danger'}
 				toastr.error({$notification->renderMessage($translator)}, {$notification->renderTitle($translator)});


### PR DESCRIPTION
- Deprecated syntax since Latte 2.7.0 (BC break)
- See https://github.com/nette/latte/releases/tag/v2.7.0
